### PR TITLE
refactor and fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-output.txt
+logs.csv
 node_modules
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 # logs-parser
-Simple data extraction from Spacemesh full node logs
 
-## Running
+Simple data extraction from Spacemesh full node logs written
+in dependency free JavaScript.
+
+## Requirements
+
+- Node.js version 10+
+
+## Usage
+
+Parse logs produced by a Spacemesh full node to produce a csv file
+with the fields `account, rewards, amount, out_txs, in_txs`.
 
 ```bash
-npm install
-node rewards log.txt logs.csv
+./rewards.js [input file] [output file]
 ```
+
+The output file defaults to `logs.csv`.

--- a/package.json
+++ b/package.json
@@ -16,9 +16,5 @@
     "url": "https://github.com/spacemeshos/logs-parser/issues"
   },
   "homepage": "https://github.com/spacemeshos/logs-parser#readme",
-  "dependencies": {
-    "fs": "0.0.1-security",
-    "path": "^0.12.7",
-    "readline": "^1.3.0"
-  }
+  "dependencies": {}
 }

--- a/rewards.js
+++ b/rewards.js
@@ -7,6 +7,7 @@
  *
  * MIT License
  * Copyright (c) 2020, Mark Tyneway
+ * Copyright (c) 2020 Spacemesh
  */
 
 'use strict';
@@ -14,8 +15,12 @@
 const readline = require('readline');
 const fs = require('fs');
 const path = require('path');
+const {once} = require('events');
 
 let accounts = new Map();
+
+if (typeof BigInt !== 'function')
+  throw new Error('Requires BigInt');
 
 async function main() {
   const args = process.argv.slice(2);
@@ -30,13 +35,26 @@ async function main() {
 
   let output = args[1] ? path.resolve(args[1]) : path.resolve('logs.csv');
 
-  const fileStream = fs.createReadStream(input);
+  const fileStream = await fs.createReadStream(input);
 
-  const rl = readline.createInterface({
+  const rl = await readline.createInterface({
     input: fileStream
   });
 
   const writer = fs.createWriteStream(output);
+
+  rl.on('line', (line) => {
+    parseRewards(line);
+    parseTransactions(line);
+  });
+
+  await write('account, rewards, amount, out_txs, in_txs\n');
+
+  await once(rl, 'close');
+
+  for (const [key, value] of accounts.entries()) {
+    await write (`${key}, ${value.total}, ${value.amount.toString()}, ${value.out_txs}, ${value.in_txs}\n`);
+  }
 
   async function write(data) {
     return new Promise((resolve, reject) => {
@@ -47,77 +65,66 @@ async function main() {
       });
     });
   }
+}
 
-  await write('account, rewards, amount, out_txs, in_txs\n');
+function parseTransactions(line) {
+  if (!line.match(/transaction processed/))
+    return;
 
-  for await (const line of rl) {
-      await parseRewards(line);
-      await parseTransactions(line);
+  const res = line.match(/{[^]*}/);
+  if (!res) {
+    console.log('WARN: unexpected regex miss, JSON not found.');
+    return;
   }
 
-  accounts.forEach( async (value, key, map) =>
-    await write (`${key}, ${value.total}, ${value.amount.toString()}, ${value.out_txs}, ${value.in_txs}\n`));
+  const data = JSON.parse(res);
+
+  // ugly but the current tx data in the log is not valid json
+  const items = data.transaction.split(', ');
+  const origin = items[1].split(' ')[1];
+  const recipient = items[2].split(' ')[1];
+
+  if (accounts.has(origin)) {
+    let v = accounts.get(origin);
+    v.out_txs++;
+    accounts.set(origin, v);
+  } else {
+    accounts.set(origin, {total: 0, amount: BigInt(0), in_txs: 0, out_txs: 1});
+  }
+
+  if (accounts.has(recipient)) {
+    let v = accounts.get(recipient);
+    v.in_txs++;
+    accounts.set (recipient, v);
+  } else {
+    accounts.set(recipient, {total: 0, amount: BigInt(0), in_txs: 1, out_txs: 0});
+  }
 }
 
-async function parseTransactions(line) {
+function parseRewards(line) {
+  if (!line.match(/Reward applied/))
+    return;
 
-    if (!line.match(/transaction processed/))
-        return;
+  const res = line.match(/{[^]*}/);
+  if (!res) {
+    console.log(`WARN: unexpected regex miss, JSON not found. ${line}`);
+    return;
+  }
 
-    const res = line.match(/{[^]*}/);
-    if (!res) {
-        console.log('WARN: unexpected regex miss, JSON not found.');
-        return;
-    }
+  const data = JSON.parse(res);
 
-    const data = JSON.parse(res);
+  if (data.account === '0x00000') {
+    return;
+  }
 
-    // ugly but the current tx data in the log is not valid json
-    const items = data.transaction.split(', ');
-    const origin = items[1].split(' ')[1];
-    const recipient = items[2].split(' ')[1];
-
-    if (accounts.has(origin)) {
-      let v = accounts.get(origin);
-      v.out_txs++;
-      accounts.set(origin, v);
-    } else {
-      accounts.set(origin, {total: 0, amount: BigInt(0), in_txs: 0, out_txs: 1});
-    }
-
-    if (accounts.has(recipient)) {
-      let v = accounts.get(recipient);
-      v.in_txs++;
-      accounts.set (recipient, v);
-    } else {
-      accounts.set(recipient, {total: 0, amount: BigInt(0), in_txs: 1, out_txs: 0});
-    }
-}
-
-async function parseRewards(line) {
-    if (!line.match(/Reward applied/))
-        return;
-
-    const res = line.match(/{[^]*}/);
-    if (!res) {
-        console.log(`WARN: unexpected regex miss, JSON not found. ${line}`);
-        return;
-    }
-
-    const data = JSON.parse(res);
-
-    if (data.account === '0x00000') {
-        return;
-    }
-
-    if (accounts.has(data.account)) {
-      let v = accounts.get(data.account);
-      v.total++;
-      v.amount = v.amount + BigInt(data.reward);
-      accounts.set (data.account, v);
-    } else {
-      accounts.set(data.account, {total: 0, amount: BigInt(data.reward), in_txs: 0, out_txs: 0});
-    }
+  if (accounts.has(data.account)) {
+    let v = accounts.get(data.account);
+    v.total++;
+    v.amount = v.amount + BigInt(data.reward);
+    accounts.set (data.account, v);
+  } else {
+    accounts.set(data.account, {total: 0, amount: BigInt(data.reward), in_txs: 0, out_txs: 0});
+  }
 }
 
 (async () => {

--- a/rewards.js
+++ b/rewards.js
@@ -37,18 +37,17 @@ async function main() {
 
   const fileStream = await fs.createReadStream(input);
 
+  const writer = fs.createWriteStream(output);
+  await write('account, rewards, amount, out_txs, in_txs\n');
+
   const rl = await readline.createInterface({
     input: fileStream
   });
-
-  const writer = fs.createWriteStream(output);
 
   rl.on('line', (line) => {
     parseRewards(line);
     parseTransactions(line);
   });
-
-  await write('account, rewards, amount, out_txs, in_txs\n');
 
   await once(rl, 'close');
 

--- a/rewards.js
+++ b/rewards.js
@@ -35,7 +35,7 @@ async function main() {
 
   let output = args[1] ? path.resolve(args[1]) : path.resolve('logs.csv');
 
-  const fileStream = await fs.createReadStream(input);
+  const fileStream = fs.createReadStream(input);
 
   const writer = fs.createWriteStream(output);
   await write('account, rewards, amount, out_txs, in_txs\n');


### PR DESCRIPTION
This PR fixes a problem when using new syntax `for await...of`, switching to the old syntax of using an eventemitter fixes the problem. When the input file is large enough, `for await...of` works as expected. My original testing used this as the input: 

```bash
$ wc -l logs.txt
416746 logs.txt
```

This PR also updates the `README`, adds the default output file to the `.gitignore` and normalizes the indentation in the script to 2 spaces. It was mixed between 2 and 4, if you have a strong preference to use 4 spaces it should be pretty easy to run it through a formatter.
